### PR TITLE
Fix typo in the word "heroku"

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # View the live webapp!
 
-[https://ucsb-cs56-musicplayer.herokoapp.com/](https://ucsb-cs56-musicplayer.herokuapp.com/)
+[https://ucsb-cs56-musicplayer.herokuapp.com/](https://ucsb-cs56-musicplayer.herokuapp.com/)
 
 # sparkjava-01
 


### PR DESCRIPTION
The word "heroku" was misspelled as "heroko" in the README.md hyperlink.